### PR TITLE
Call colored-traceback with python -m

### DIFF
--- a/colored_traceback/__main__.py
+++ b/colored_traceback/__main__.py
@@ -1,0 +1,14 @@
+import sys
+import colored_traceback
+
+colored_traceback.add_hook(always=True)
+
+if len(sys.argv) <= 1:
+    raise IOError("Missing python file argument. Please use `python -m colored_traceback somefile.py args...`")
+
+file = sys.argv[1]
+sys.argv = sys.argv[1:]
+
+with open(file) as f:
+    code = compile(f.read(), file, 'exec')
+    exec(code)


### PR DESCRIPTION
This PR should close #3.

Let's imaging a `foobar.py` file containing `raise Exception("too bad")`.

**python foobar.py** 
```
Traceback (most recent call last):
  File "foobar.py", line 1, in <module>
    raise Exception("too bad")
Exception: too bad
```
**python -m colored_traceback foobar.py** 
```python
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/azmeuk/dev/colored-traceback.py/colored_traceback/__main__.py", line 14, in <module>
    exec(code)
  File "foobar.py", line 1, in <module>
    raise Exception("too bad")
Exception: too bad
```

The main drawback is that the traceback is a bit longer here, but it is usable.
The main benefit is that anyone can test colored_traceback without writing any code.