### PR TITLE
Implement 'colors' option.

### DIFF
--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -1,12 +1,12 @@
 import sys
 
 
-def add_hook(always=False, style='default', debug=False):
+def add_hook(always=False, style='default', colors=None, debug=False):
     isatty = getattr(sys.stderr, 'isatty', lambda: False)
     if always or isatty():
         try:
             import pygments  # flake8:noqa
-            colorizer = Colorizer(style, debug)
+            colorizer = Colorizer(style, colors, debug)
             sys.excepthook = colorizer.colorize_traceback
         except ImportError:
             if debug:
@@ -15,8 +15,9 @@ def add_hook(always=False, style='default', debug=False):
 
 class Colorizer(object):
 
-    def __init__(self, style, debug=False):
+    def __init__(self, style, colors, debug=False):
         self.style = style
+        self.colors = colors
         self.debug = debug
 
     def colorize_traceback(self, type, value, tb):
@@ -29,7 +30,7 @@ class Colorizer(object):
 
     @property
     def formatter(self):
-        colors = _get_term_color_support()
+        colors = self.colors or _get_term_color_support()
         if self.debug:
             sys.stderr.write("Detected support for %s colors\n" % colors)
         if colors == 256:

--- a/test.py
+++ b/test.py
@@ -11,7 +11,7 @@ def main():
             import colored_traceback.auto
     else:
         from colored_traceback import add_hook
-        add_hook(always=args.always, debug=args.debug)
+        add_hook(always=args.always, colors=args.colors, debug=args.debug)
 
     x = object()
     x.thing()
@@ -22,6 +22,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--shortcut", action='store_true')
     parser.add_argument("--always", action='store_true')
+    parser.add_argument("--colors", action='store', type=int)
     parser.add_argument("--debug", action='store_true')
     return parser.parse_args()
 


### PR DESCRIPTION
Option to let the user define the amount of terminal colors manually.
Fixes #5 