### PR TITLE
Do not strip the traceback

### DIFF
--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -23,7 +23,7 @@ class Colorizer(object):
         import traceback
         import pygments.lexers
         tb_text = "".join(traceback.format_exception(type, value, tb))
-        lexer = pygments.lexers.get_lexer_by_name("pytb", stripall=True)
+        lexer = pygments.lexers.get_lexer_by_name("pytb")
         tb_colored = pygments.highlight(tb_text, lexer, self.formatter)
         self.stream.write(tb_colored)
 


### PR DESCRIPTION
`SyntaxError` tracebacks start with two spaces; when stripped the traceback is not properly highlighted. Since the only text that is being lexed is produced by the `traceback` module, there is no need to strip anything.

Fixes #8