### PR TITLE
Use py3tb when running on Python 3

### DIFF
--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -23,7 +23,8 @@ class Colorizer(object):
         import traceback
         import pygments.lexers
         tb_text = "".join(traceback.format_exception(type, value, tb))
-        lexer = pygments.lexers.get_lexer_by_name("pytb", stripall=True)
+        lexer_name = "pytb" if sys.version_info.major < 3 else "py3tb"
+        lexer = pygments.lexers.get_lexer_by_name(lexer_name, stripall=True)
         tb_colored = pygments.highlight(tb_text, lexer, self.formatter)
         self.stream.write(tb_colored)
 


### PR DESCRIPTION
Python 3 tracebacks have more features, and the py3tb lexer can handle these much better than the standard pytb.

Fixes #10

Note that this pull request could conflict with #9, but the fix is simple: just drop the `, stripall=True` part from the `get_lexer_by_name()` call.