### PR TITLE
Refactor for efficiency

### DIFF
--- a/colored_traceback/__init__.py
+++ b/colored_traceback/__init__.py
@@ -1,1 +1,1 @@
-from .colored_traceback import add_hook, Colorizer
+from .colored_traceback import add_hook

--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -29,35 +29,34 @@ if PYGMENTS:
         curses.setupterm()
         return curses.tigetnum('colors')
 
-    def _determine_formatter(self):
+    def _determine_formatter(style="default", debug=False):
         colors = _get_term_color_support()
-        if self.debug:
+        if debug:
             sys.stderr.write("Detected support for %s colors\n" % colors)
         if colors == 256:
-            fmt_options = {'style': self.style}
-        elif self.style in ('light', 'dark'):
-            fmt_options = {'bg': self.style}
+            fmt_options = {'style': style}
+        elif style in ('light', 'dark'):
+            fmt_options = {'bg': style}
         else:
             fmt_options = {'bg': 'dark'}
         fmt_alias = 'terminal256' if colors == 256 else 'terminal'
         try:
             return get_formatter_by_name(fmt_alias, **fmt_options)
         except ClassNotFound as ex:
-            if self.debug:
+            if debug:
                 sys.stderr.write(str(ex) + "\n")
             return get_formatter_by_name(fmt_alias)
 
     LEXER = get_lexer_by_name(
         "pytb" if sys.version_info.major < 3 else "py3tb"
     )
-    FORMATTER = _determine_formatter()
 
     class Colorizer(object):
         def __init__(self, style, debug=False):
             self.style = style
             self.debug = debug
             self.lexer = LEXER
-            self.formatter = FORMATTER
+            self.formatter = _determine_formatter(style, debug)
 
         def colorize_traceback(self, type, value, tb):
             tb_text = "".join(traceback.format_exception(type, value, tb))

--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -1,34 +1,35 @@
 import sys
+import traceback
+
+try:
+    from pygments import highlight
+    from pygments.lexers import get_lexer_by_name
+    from pygments.formatters import get_formatter_by_name
+    from pygments.util import ClassNotFound
+
+    PYGMENTS = True
+except ImportError:
+    PYGMENTS = False
 
 
-def add_hook(always=False, style='default', debug=False):
-    isatty = getattr(sys.stderr, 'isatty', lambda: False)
-    if always or isatty():
+if PYGMENTS:
+    try:
+        import colorama
+        translate_stream = colorama.AnsiToWin32
+    except ImportError:
+        def translate_stream(stream):
+            return stream
+
+    def _get_term_color_support():
         try:
-            import pygments  # flake8:noqa
-            colorizer = Colorizer(style, debug)
-            sys.excepthook = colorizer.colorize_traceback
+            import curses
         except ImportError:
-            if debug:
-                sys.stderr.write("Failed to add coloring hook; pygments not available\n")
+            # Probably Windows, which doesn't have great curses support
+            return 16
+        curses.setupterm()
+        return curses.tigetnum('colors')
 
-
-class Colorizer(object):
-
-    def __init__(self, style, debug=False):
-        self.style = style
-        self.debug = debug
-
-    def colorize_traceback(self, type, value, tb):
-        import traceback
-        import pygments.lexers
-        tb_text = "".join(traceback.format_exception(type, value, tb))
-        lexer = pygments.lexers.get_lexer_by_name("pytb", stripall=True)
-        tb_colored = pygments.highlight(tb_text, lexer, self.formatter)
-        self.stream.write(tb_colored)
-
-    @property
-    def formatter(self):
+    def _determine_formatter(self):
         colors = _get_term_color_support()
         if self.debug:
             sys.stderr.write("Detected support for %s colors\n" % colors)
@@ -38,30 +39,45 @@ class Colorizer(object):
             fmt_options = {'bg': self.style}
         else:
             fmt_options = {'bg': 'dark'}
-        from pygments.formatters import get_formatter_by_name
-        import pygments.util
         fmt_alias = 'terminal256' if colors == 256 else 'terminal'
         try:
             return get_formatter_by_name(fmt_alias, **fmt_options)
-        except pygments.util.ClassNotFound as ex:
+        except ClassNotFound as ex:
             if self.debug:
                 sys.stderr.write(str(ex) + "\n")
             return get_formatter_by_name(fmt_alias)
 
-    @property
-    def stream(self):
-        try:
-            import colorama
-            return colorama.AnsiToWin32(sys.stderr)
-        except ImportError:
-            return sys.stderr
+    LEXER = get_lexer_by_name(
+        "pytb" if sys.version_info.major < 3 else "py3tb"
+    )
+    FORMATTER = _determine_formatter()
+
+    class Colorizer(object):
+        def __init__(self, style, debug=False):
+            self.style = style
+            self.debug = debug
+            self.lexer = LEXER
+            self.formatter = FORMATTER
+
+        def colorize_traceback(self, type, value, tb):
+            tb_text = "".join(traceback.format_exception(type, value, tb))
+            tb_colored = highlight(tb_text, self.lexer, self.formatter)
+            self.stream.write(tb_colored)
+
+        @property
+        def stream(self):
+            return translate_stream(sys.stderr)
+
+    def add_hook(always=False, style='default', debug=False):
+        isatty = getattr(sys.stderr, 'isatty', lambda: False)
+        if always or isatty():
+            colorizer = Colorizer(style, debug)
+            sys.excepthook = colorizer.colorize_traceback
 
 
-def _get_term_color_support():
-    try:
-        import curses
-    except ImportError:
-        # Probably Windows, which doesn't have great curses support
-        return 16
-    curses.setupterm()
-    return curses.tigetnum('colors')
+else:
+    def add_hook(debug=False, **kwargs):
+        if debug:
+            sys.stderr.write(
+                "Failed to add coloring hook; pygments not available\n"
+            )


### PR DESCRIPTION
This is a larger refactoring that avoids re-creating objects each time there is a traceback to print.

- Move imports to module level
- Make most object definitions dependent on pygments being available
- Create a lexer and formatter just once
- Determine if colorama support is available just once

It also incorporates pull requests #9 and #11, so could be seen as a replacement for those.