### PR TITLE
support for NO_COLOR environment variable 

### DIFF
--- a/colored_traceback/colored_traceback.py
+++ b/colored_traceback/colored_traceback.py
@@ -1,7 +1,11 @@
 import sys
+import os
 
 
 def add_hook(always=False, style='default', debug=False):
+    no_color = os.environ.get("NO_COLOR", "")   # https://no-color.org
+    if no_color:
+        return
     isatty = getattr(sys.stderr, 'isatty', lambda: False)
     if always or isatty():
         try:


### PR DESCRIPTION
Hello, I really like colored tracebacks. But on some occasions I think it is quite useful to disable colored output easily.
Pleas see https://no-color.org for details.