### PR TITLE
Require 'colorama' on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,8 @@ Or directly:
     git clone http://www.github.com/staticshock/colored-traceback.py
     python setup.py install
 
-On Windows, which has no real support for ANSI escape sequences, there's an
-additional dependency on `colorama`:
-
-.. code-block:: bash
-
-    pip install colorama
+On Windows, which has no real support for ANSI escape sequences, this will
+also install `colorama`.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 extra_args = {}
 if has_setuptools:
-    extra_args['install_requires'] = ['pygments']
+    extra_args['install_requires'] = ['pygments', 'colorama; os_name == "nt"']
 
 setup(
     name='colored-traceback',


### PR DESCRIPTION
Add `colorama` as a Windows-only dependency. See [Python packaging docs](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) for syntax explanation.

Fixes #7