### PR TITLE
Remove deprecated local install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,8 @@ Or directly:
 .. code-block:: bash
 
     git clone http://www.github.com/staticshock/colored-traceback.py
-    python setup.py install
+    cd colored-traceback.py
+    pip install .
 
 On Windows, which has no real support for ANSI escape sequences, there's an
 additional dependency on `colorama`:


### PR DESCRIPTION
See [Python packaging docs](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).